### PR TITLE
add ability to set request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ has been modified on the server since the last download <em>(default:
 <dd>The username for <code>Basic</code> authentication <em>(optional)</em></dd>
 <dt>password</dt>
 <dd>The password for <code>Basic</code> authentication <em>(optional)</em></dd>
+<dt>header</dt>
+<dd>The name and value of a request header to set when making the download
+request <em>(optional)</em></dd>
 </dl>
 
 License

--- a/src/main/java/de/undercouch/gradle/tasks/download/Download.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/Download.java
@@ -17,6 +17,7 @@ package de.undercouch.gradle.tasks.download;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.util.Map;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.internal.tasks.TaskStateInternal;
@@ -91,7 +92,17 @@ public class Download extends DefaultTask implements DownloadSpec {
     public void password(String password) {
         action.password(password);
     }
-    
+
+    @Override
+    public void headers(Map<String, String> headers) {
+        action.headers(headers);
+    }
+
+    @Override
+    public void header(String name, String value) {
+        action.header(name, value);
+    }
+
     @Override
     public Object getSrc() {
         return action.getSrc();
@@ -130,5 +141,15 @@ public class Download extends DefaultTask implements DownloadSpec {
     @Override
     public String getPassword() {
         return action.getPassword();
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return action.getHeaders();
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return action.getHeader(name);
     }
 }

--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
@@ -28,6 +28,8 @@ import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
 import org.apache.tools.ant.util.Base64Converter;
@@ -50,6 +52,7 @@ public class DownloadAction implements DownloadSpec {
     private boolean compress = true;
     private String username;
     private String password;
+    private Map<String, String> headers;
     
     private ProgressLogger progressLogger;
     private String size;
@@ -226,6 +229,13 @@ public class DownloadAction implements DownloadSpec {
                 Base64Converter encoder = new Base64Converter();
                 String encoding = encoder.encode(up.getBytes());
                 uc.setRequestProperty("Authorization", "Basic " + encoding);
+            }
+
+            //set headers
+            if (headers != null) {
+                for (Map.Entry<String, String> headerEntry : headers.entrySet()) {
+                    uc.setRequestProperty(headerEntry.getKey(), headerEntry.getValue());
+                }
             }
             
             //enable compression
@@ -426,7 +436,20 @@ public class DownloadAction implements DownloadSpec {
     public void password(String password) {
         this.password = password;
     }
-    
+
+    @Override
+    public void headers(Map<String, String> headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public void header(String name, String value) {
+        if (headers == null) {
+            headers = new LinkedHashMap<String, String>();
+        }
+        headers.put(name, value);
+    }
+
     @Override
     public Object getSrc() {
         if (sources != null && sources.size() == 1) {
@@ -468,5 +491,18 @@ public class DownloadAction implements DownloadSpec {
     @Override
     public String getPassword() {
         return password;
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    @Override
+    public String getHeader(String name) {
+        if (headers == null) {
+            return null;
+        }
+        return headers.get(name);
     }
 }

--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadSpec.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadSpec.java
@@ -16,6 +16,7 @@ package de.undercouch.gradle.tasks.download;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.util.Map;
 
 /**
  * An interface for classes that perform file downloads
@@ -71,7 +72,20 @@ public interface DownloadSpec {
      * @param password the password
      */
     void password(String password);
-    
+
+    /**
+     * Sets the HTTP request headers to us when downloading
+     * @param headers a Map of header names to values
+     */
+    void headers(Map<String, String> headers);
+
+    /**
+     * Sets an HTTP request header to use when downloading
+     * @param name name of the HTTP header
+     * @param value value of the HTTP header
+     */
+    void header(String name, String value);
+
     /**
      * @return the download source(s), either a URL or a list of URLs
      */
@@ -111,4 +125,15 @@ public interface DownloadSpec {
      * @return the password for <code>Basic</code> authentication
      */
     String getPassword();
+
+    /**
+     * @return the HTTP request headers to use when downloading
+     */
+    Map<String, String> getHeaders();
+
+    /**
+     * @param name name of the HTTP header
+     * @return the value of the HTTP header
+     */
+    String getHeader(String name);
 }


### PR DESCRIPTION
This adds the ability to set HTTP request headers for download tasks.

For example:

```
download {
    src 'http://download.oracle.com/otn-pub/java/jdk/8-b132/jdk-8-macosx-x64.dmg'
    dest buildDir
    header 'Cookie', 'oraclelicense=accept-securebackup-cookie'
}
```
