### PR TITLE
Added support for java.io.OutputStream as dest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ bin/
 .settings/
 .classpath
 .project
+example/example.iml
+gradle-download-task.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The download task and the extension support the following properties
 <dd>The URL from which to retrieve the file. Can be a list of URLs if
 multiple files shoud be downloaded. <em>(required)</em></dd>
 <dt>dest</dt>
-<dd>The file or directory where to store the file <em>(required)</em> or an instance of a <em>java.io.OutputStream</em></dd>
+<dd>The file or directory where to store the file <em>(required)</em> or an instance of a <code>java.io.OutputStream</code></dd>
 <dt>quiet</dt>
 <dd><code>true</code> if progress information should not be displayed
 <em>(default: <code>false</code>)</em></dd>

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The download task and the extension support the following properties
 <dd>The URL from which to retrieve the file. Can be a list of URLs if
 multiple files shoud be downloaded. <em>(required)</em></dd>
 <dt>dest</dt>
-<dd>The file or directory where to store the file <em>(required)</em></dd>
+<dd>The file or directory where to store the file <em>(required)</em> or an instance of a <em>java.io.OutputStream</em></dd>
 <dt>quiet</dt>
 <dd><code>true</code> if progress information should not be displayed
 <em>(default: <code>false</code>)</em></dd>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.1-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2-bin.zip

--- a/src/main/java/de/undercouch/gradle/tasks/download/Download.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/Download.java
@@ -17,8 +17,10 @@ package de.undercouch.gradle.tasks.download;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.util.AbstractCollection;
 import java.util.Map;
 
+import de.undercouch.gradle.tasks.download.destination.AbstractDestination;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.tasks.TaskAction;
@@ -109,8 +111,8 @@ public class Download extends DefaultTask implements DownloadSpec {
     }
     
     @Override
-    public File getDest() {
-        return action.getDest();
+    public Object getDest() {
+        return ((AbstractDestination)action.getDest()).getValue();
     }
     
     @Override

--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadSpec.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadSpec.java
@@ -94,7 +94,7 @@ public interface DownloadSpec {
     /**
      * @return the download destination
      */
-    File getDest();
+    Object getDest();
     
     /**
      * @return the quiet flag

--- a/src/main/java/de/undercouch/gradle/tasks/download/destination/AbstractDestination.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/destination/AbstractDestination.java
@@ -1,0 +1,42 @@
+package de.undercouch.gradle.tasks.download.destination;
+
+import java.io.File;
+import java.io.OutputStream;
+
+/**
+ * Created by berndfarka on 11.11.14.
+ *
+ * Abstract class abstracting the destionation
+ *
+ */
+public abstract class AbstractDestination {
+
+    /**
+     * creates an
+     * @param dest to be downloaded, can be an CharSequence, File or OutputStream
+     * @return An instance of a AbstractDestination and never null
+     * @throws java.lang.IllegalArgumentException if dest is not supported
+     */
+    public static AbstractDestination create(Object dest){
+        if (dest == null) {
+            throw new IllegalArgumentException("Please provide a download destination");
+        }
+
+        if (dest instanceof CharSequence) {
+            return new FileDestination(dest.toString());
+        } else if (dest instanceof File) {
+            return new FileDestination((File)dest);
+        }else if(dest instanceof OutputStream){
+            return new StreamDestination((OutputStream) dest);
+        }
+            throw new IllegalArgumentException("Download destination must " +
+                    "either be a File or a CharSequence");
+
+    }
+
+    public abstract Object getValue();
+
+
+
+
+}

--- a/src/main/java/de/undercouch/gradle/tasks/download/destination/FileDestination.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/destination/FileDestination.java
@@ -1,0 +1,29 @@
+package de.undercouch.gradle.tasks.download.destination;
+
+import java.io.File;
+
+/**
+ * Created by berndfarka on 11.11.14.
+ */
+public class FileDestination extends AbstractDestination {
+
+    private final File dest;
+
+
+    public FileDestination(File dest) {
+        this.dest = dest;
+    }
+
+    public FileDestination(CharSequence dest){
+        this(new File(dest.toString()));
+    }
+
+    public File getFile(){
+        return dest;
+    }
+
+    @Override
+    public Object getValue() {
+        return dest;
+    }
+}

--- a/src/main/java/de/undercouch/gradle/tasks/download/destination/StreamDestination.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/destination/StreamDestination.java
@@ -1,0 +1,28 @@
+package de.undercouch.gradle.tasks.download.destination;
+
+import org.simpleframework.util.buffer.Stream;
+
+import java.io.File;
+import java.io.OutputStream;
+
+/**
+ * Created by berndfarka on 11.11.14.
+ */
+public class StreamDestination extends AbstractDestination {
+
+    private final OutputStream destination;
+
+    public StreamDestination(OutputStream destination) {
+        this.destination = destination;
+    }
+
+
+    public OutputStream getStream(){
+        return destination;
+    }
+
+    @Override
+    public Object getValue() {
+        return destination;
+    }
+}

--- a/src/test/java/de/undercouch/gradle/tasks/download/DownloadTaskPluginTest.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/DownloadTaskPluginTest.java
@@ -17,6 +17,7 @@ package de.undercouch.gradle.tasks.download;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -148,7 +149,7 @@ public class DownloadTaskPluginTest {
         Project project = ProjectBuilder.builder().build();
         
         Map<String, Object> applyParams = new HashMap<String, Object>();
-        applyParams.put("plugin", "download-task");
+        applyParams.put("plugin", "de.undercouch.download");
         project.apply(applyParams);
         
         Map<String, Object> taskParams = new HashMap<String, Object>();
@@ -181,7 +182,19 @@ public class DownloadTaskPluginTest {
         byte[] dstContents = FileUtils.readFileToByteArray(dst);
         assertArrayEquals(contents, dstContents);
     }
-    
+
+    @Test
+    public void downloadToByteArray() throws Exception{
+        Download t = makeProjectAndTask();
+        t.src(makeSrc(TEST_FILE_NAME));
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        t.dest(out);
+        t.execute();
+
+
+        assertArrayEquals(contents, out.toByteArray());
+    }
+
     /**
      * Tests if a single file can be downloaded from a URL
      * @throws Exception if anything goes wrong


### PR DESCRIPTION
#15 

I like you plugin very much, but sometimes I'm downloading files wich I directly would need in memory, therefore its not the best to save it on the disk an read it after downloading, so i think to support OutputStreams as "dest" would resolve all my problems..

in addition i tried to execute the plugin with gradle 2.2 and fixed the unit tests