### PR TITLE
onlyIfNewer with behavior like in wget

### DIFF
--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
@@ -123,6 +123,11 @@ public class DownloadAction implements DownloadSpec {
             timestamp = destFile.lastModified();
         }
         
+        long fileLength = 0;
+        if (destFile.exists()) {
+            fileLength = destFile.length();
+        }
+        
         //create progress logger
         if (!quiet) {
             //we are about to access an internal class. Use reflection here to provide
@@ -148,7 +153,7 @@ public class DownloadAction implements DownloadSpec {
         }
         
         //open URL connection
-        URLConnection conn = openConnection(src, timestamp, destFile.length(), project);
+        URLConnection conn = openConnection(src, timestamp, fileLength, project);
         if (conn == null) {
             return;
         }
@@ -205,12 +210,12 @@ public class DownloadAction implements DownloadSpec {
      * server if the given timestamp is greater than 0.
      * @param src the source URL to open a connection for
      * @param timestamp the timestamp of the destination file
-     * @param length the length of the destination file
+     * @param fileLength the length of the destination file
      * @param project the project to be built
      * @return the URLConnection or null if the download should be skipped
      * @throws IOException if the connection could not be opened
      */
-    private URLConnection openConnection(URL src, long timestamp, long length,
+    private URLConnection openConnection(URL src, long timestamp, long fileLength,
             Project project) throws IOException {
         int redirects = MAX_NUMBER_OF_REDIRECTS;
         
@@ -219,13 +224,14 @@ public class DownloadAction implements DownloadSpec {
             long contentLength = parseContentLength(uc);
             uc = uc.getURL().openConnection();
         	
-        	if (uc instanceof HttpURLConnection) {
+            if (uc instanceof HttpURLConnection) {
                 HttpURLConnection httpConnection = (HttpURLConnection)uc;
                 httpConnection.setInstanceFollowRedirects(true);
             }
             
-            //set If-Modified-Since header
-            if (timestamp > 0 && contentLength == length) {
+            //set If-Modified-Since header only if the sizes of the files match
+            boolean isSizesMatch = contentLength == fileLength;
+            if (timestamp > 0 && isSizesMatch) {
                 uc.setIfModifiedSince(timestamp);
             }
             
@@ -255,8 +261,8 @@ public class DownloadAction implements DownloadSpec {
                 HttpURLConnection httpConnection = (HttpURLConnection)uc;
                 int responseCode = httpConnection.getResponseCode();
                 long lastModified = httpConnection.getLastModified();
-                if (responseCode == HttpURLConnection.HTTP_NOT_MODIFIED ||
-                        (lastModified != 0 && timestamp >= lastModified && contentLength == length)) {
+                if (responseCode == HttpURLConnection.HTTP_NOT_MODIFIED && isSizesMatch ||
+                        (lastModified != 0 && timestamp >= lastModified && isSizesMatch)) {
                     if (!quiet) {
                         project.getLogger().info("Not modified. Skipping '" + src + "'");
                     }

--- a/src/test/java/de/undercouch/gradle/tasks/download/DownloadTaskPluginTest.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/DownloadTaskPluginTest.java
@@ -214,6 +214,24 @@ public class DownloadTaskPluginTest {
         byte[] dstContents = FileUtils.readFileToByteArray(dst);
         assertArrayEquals(contents, dstContents);
     }
+
+    /**
+     * Tests if a single file can be downloaded from a URL
+     * only if the source file is newer
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    public void downloadSingleURLOnlyIfNewer() throws Exception {
+        Download t = makeProjectAndTask();
+        t.src(new URL(makeSrc(TEST_FILE_NAME)));
+        File dst = folder.newFile();
+        t.dest(dst);
+        t.onlyIfNewer(true);
+        t.execute();
+        
+        byte[] dstContents = FileUtils.readFileToByteArray(dst);
+        assertArrayEquals(contents, dstContents);
+    }
     
     /**
      * Tests if a single file can be downloaded to a directory


### PR DESCRIPTION
If the sizes of the files do not match, download the remote file no matter what the time-stamps says.