### PR TITLE
Fix #26 project relative string paths for Download task dest property and…

### DIFF
--- a/src/main/java/de/undercouch/gradle/tasks/download/Download.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/Download.java
@@ -34,7 +34,12 @@ import org.gradle.api.tasks.TaskAction;
  * @author Michel Kraemer
  */
 public class Download extends DefaultTask implements DownloadSpec {
-    private DownloadAction action = new DownloadAction();
+    private final DownloadAction action;
+
+    public Download() {
+      super();
+      action = new DownloadAction(getProject());
+    }
     
     /**
      * Starts downloading
@@ -42,7 +47,7 @@ public class Download extends DefaultTask implements DownloadSpec {
      */
     @TaskAction
     public void download() throws IOException {
-        action.execute(getProject());
+        action.execute();
         if (action.isSkipped()) {
             //we are about to access an internal class. Use reflection here to provide
             //as much compatibility to previous Gradle versions as possible (see issue #16)

--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
@@ -46,6 +46,7 @@ import org.gradle.logging.ProgressLoggerFactory;
 public class DownloadAction implements DownloadSpec {
     private static final int MAX_NUMBER_OF_REDIRECTS = 30;
     
+    private final Project project;
     private List<URL> sources = new ArrayList<URL>(1);
     private File dest;
     private boolean quiet = false;
@@ -63,12 +64,15 @@ public class DownloadAction implements DownloadSpec {
     
     private int skipped = 0;
     
+    public DownloadAction(Project project) {
+      this.project = project;
+    }
+
     /**
      * Starts downloading
-     * @param project the project to be built
      * @throws IOException if the file could not downloaded
      */
-    public void execute(Project project) throws IOException {
+    public void execute() throws IOException {
         if (sources == null || sources.isEmpty()) {
             throw new IllegalArgumentException("Please provide a download source");
         }
@@ -87,11 +91,11 @@ public class DownloadAction implements DownloadSpec {
         }
         
         for (URL src : sources) {
-            execute(src, project);
+            execute(src);
         }
     }
     
-    private void execute(URL src, Project project) throws IOException {
+    private void execute(URL src) throws IOException {
         File destFile = dest;
         if (destFile.isDirectory()) {
             //guess name from URL
@@ -148,7 +152,7 @@ public class DownloadAction implements DownloadSpec {
         }
         
         //open URL connection
-        URLConnection conn = openConnection(src, timestamp, project);
+        URLConnection conn = openConnection(src, timestamp);
         if (conn == null) {
             return;
         }
@@ -209,8 +213,7 @@ public class DownloadAction implements DownloadSpec {
      * @return the URLConnection or null if the download should be skipped
      * @throws IOException if the connection could not be opened
      */
-    private URLConnection openConnection(URL src, long timestamp,
-            Project project) throws IOException {
+    private URLConnection openConnection(URL src, long timestamp) throws IOException {
         int redirects = MAX_NUMBER_OF_REDIRECTS;
         
         URLConnection uc = src.openConnection();
@@ -412,7 +415,7 @@ public class DownloadAction implements DownloadSpec {
         }
         
         if (dest instanceof CharSequence) {
-            this.dest = new File(dest.toString());
+            this.dest = project.file(dest.toString());
         } else if (dest instanceof File) {
             this.dest = (File)dest;
         } else {

--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadExtension.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadExtension.java
@@ -39,9 +39,9 @@ public class DownloadExtension implements Configurable<DownloadExtension> {
     
     @Override
     public DownloadExtension configure(@SuppressWarnings("rawtypes") Closure cl) {
-        DownloadAction da = ConfigureUtil.configure(cl, new DownloadAction());
+        DownloadAction da = ConfigureUtil.configure(cl, new DownloadAction(project));
         try {
-            da.execute(project);
+            da.execute();
         } catch (IOException e) {
             throw new IllegalStateException("Could not download file", e);
         }

--- a/src/main/java/de/undercouch/gradle/tasks/download/Verify.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/Verify.java
@@ -33,7 +33,12 @@ import org.gradle.api.tasks.TaskAction;
  * @author Michel Kraemer
  */
 public class Verify extends DefaultTask implements VerifySpec {
-    private final VerifyAction action = new VerifyAction();
+    private final VerifyAction action;
+
+    public Verify() {
+      super();
+      action = new VerifyAction(getProject());
+    }
     
     /**
      * Starts verifying
@@ -42,7 +47,7 @@ public class Verify extends DefaultTask implements VerifySpec {
      */
     @TaskAction
     public void verify() throws IOException, NoSuchAlgorithmException {
-        action.execute(getProject());
+        action.execute();
     }
 
     @Override

--- a/src/main/java/de/undercouch/gradle/tasks/download/VerifyAction.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/VerifyAction.java
@@ -30,10 +30,15 @@ import org.gradle.api.Project;
  * @author Michel Kraemer
  */
 public class VerifyAction implements VerifySpec {
+    private final Project project;
     private File src;
     private String algorithm = "MD5";
     private String checksum;
     
+    public VerifyAction(Project project) {
+        this.project = project;
+    }
+
     private String toHex(byte[] barr) {
         StringBuffer result = new StringBuffer();
         for (byte b : barr) {
@@ -44,11 +49,10 @@ public class VerifyAction implements VerifySpec {
     
     /**
      * Starts verifying
-     * @param project the project to be built
      * @throws IOException if the file could not verified
      * @throws NoSuchAlgorithmException if the given algorithm is not available
      */
-    public void execute(Project project) throws IOException, NoSuchAlgorithmException {
+    public void execute() throws IOException, NoSuchAlgorithmException {
         if (src == null) {
             throw new IllegalArgumentException("Please provide a file to verify");
         }
@@ -92,7 +96,7 @@ public class VerifyAction implements VerifySpec {
         }
         
         if (src instanceof CharSequence) {
-            src = new File(src.toString());
+            src = project.file(src.toString());
         }
         if (src instanceof File) {
             this.src = (File)src;


### PR DESCRIPTION
Verified that now specifications like this resolve to same location regardless of where the task is run in a mult-project build:

task myFileDownload(type: Download) {
    src "http://someserver.net/myfile.tar"
    dest 'destfile.tar'
}
