### PR TITLE
Simplify .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 sudo: false
-script: "chmod 755 gradlew && ./gradlew install && ./gradlew check"
+
+language: java
+
+install: ./gradlew install


### PR DESCRIPTION
We should use the Java environment/language on TravisCI because it will automatically detect that this project is based on Gradle and will fill in the necessary build steps automatically.