### PR TITLE
Register task output files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
 }
 
 apply plugin: 'java-gradle-plugin'
+apply plugin: 'jacoco'
 apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'

--- a/src/main/java/de/undercouch/gradle/tasks/download/Download.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/Download.java
@@ -18,9 +18,13 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
+import java.util.List;
 import java.util.Map;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.Task;
+import org.gradle.api.specs.Spec;
+import org.gradle.api.tasks.OutputFiles;
 import org.gradle.api.tasks.TaskAction;
 
 /**
@@ -41,6 +45,12 @@ public class Download extends DefaultTask implements DownloadSpec {
      */
     public Download() {
         action = new DownloadAction(getProject());
+        getOutputs().upToDateWhen(new Spec<Task>() {
+            @Override
+            public boolean isSatisfiedBy(Task task) {
+                return !(isOnlyIfNewer() || isOverwrite());
+            }
+        });
     }
     
     /**
@@ -73,6 +83,11 @@ public class Download extends DefaultTask implements DownloadSpec {
         } catch (Exception e) {
             //just ignore
         }
+    }
+
+    @OutputFiles
+    public List<File> getOutputFiles() {
+        return action.getOutputFiles();
     }
     
     @Override

--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
@@ -139,25 +139,9 @@ public class DownloadAction implements DownloadSpec {
             execute(src);
         }
     }
-    
+
     private void execute(URL src) throws IOException {
-        File destFile = dest;
-        if (destFile.isDirectory()) {
-            //guess name from URL
-            String name = src.toString();
-            if (name.endsWith("/")) {
-                name = name.substring(0, name.length() - 1);
-            }
-            name = name.substring(name.lastIndexOf('/') + 1);
-            destFile = new File(dest, name);
-        } else {
-            //create destination directory
-            File parent = destFile.getParentFile();
-            if (parent != null) {
-                parent.mkdirs();
-            }
-        }
-        
+        final File destFile = destFile(src);
         if (!overwrite && destFile.exists()) {
             if (!quiet) {
                 project.getLogger().info("Destination file already exists. "
@@ -293,6 +277,26 @@ public class DownloadAction implements DownloadSpec {
         if (onlyIfNewer && newTimestamp > 0) {
             destFile.setLastModified(newTimestamp);
         }
+    }
+
+    private File destFile(URL src) {
+        File destFile = dest;
+        if (destFile.isDirectory()) {
+            //guess name from URL
+            String name = src.toString();
+            if (name.endsWith("/")) {
+                name = name.substring(0, name.length() - 1);
+            }
+            name = name.substring(name.lastIndexOf('/') + 1);
+            destFile = new File(dest, name);
+        } else {
+            //create destination directory
+            File parent = destFile.getParentFile();
+            if (parent != null) {
+                parent.mkdirs();
+            }
+        }
+        return destFile;
     }
     
     /**
@@ -555,6 +559,14 @@ public class DownloadAction implements DownloadSpec {
      */
     boolean isSkipped() {
         return skipped == sources.size();
+    }
+
+    List<File> getOutputFiles() {
+        List<File> files = new ArrayList<File>(sources.size());
+        for (URL src : sources) {
+            files.add(destFile(src));
+        }
+        return files;
     }
     
     @Override

--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
@@ -116,10 +116,7 @@ public class DownloadAction implements DownloadSpec {
         if (sources.isEmpty()) {
             throw new IllegalArgumentException("Please provide a download source");
         }
-        if (dest == null) {
-            throw new IllegalArgumentException("Please provide a download destination");
-        }
-        
+
         if (dest.equals(project.getBuildDir())) {
             //make sure build dir exists
             dest.mkdirs();
@@ -165,11 +162,8 @@ public class DownloadAction implements DownloadSpec {
             throw new IllegalStateException("Unable to download " + src +
                     " in offline mode.");
         }
-        
-        long timestamp = 0;
-        if (onlyIfNewer && destFile.exists()) {
-            timestamp = destFile.lastModified();
-        }
+
+        final long timestamp = onlyIfNewer && destFile.exists() ? destFile.lastModified() : 0;
         
         //create progress logger
         if (!quiet) {
@@ -192,10 +186,6 @@ public class DownloadAction implements DownloadSpec {
             //open URL connection
             CloseableHttpResponse response = openConnection(httpHost, src.getFile(),
                     timestamp, client);
-            if (response == null) {
-                return;
-            }
-            
             //check if file on server was modified
             long lastModified = parseLastModified(response);
             int code = response.getStatusLine().getStatusCode();
@@ -280,6 +270,10 @@ public class DownloadAction implements DownloadSpec {
     }
 
     private File destFile(URL src) {
+        if (dest == null) {
+            throw new IllegalArgumentException("Please provide a download destination");
+        }
+
         File destFile = dest;
         if (destFile.isDirectory()) {
             //guess name from URL
@@ -366,7 +360,7 @@ public class DownloadAction implements DownloadSpec {
      * @param file the file to request
      * @param timestamp the timestamp of the destination file, in milliseconds
      * @param client the HTTP client to use to perform the request
-     * @return the URLConnection or null if the download should be skipped
+     * @return the URLConnection
      * @throws IOException if the connection could not be opened
      */
     private CloseableHttpResponse openConnection(HttpHost httpHost, String file,

--- a/src/test/java/de/undercouch/gradle/tasks/download/DownloadTest.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/DownloadTest.java
@@ -129,6 +129,18 @@ public class DownloadTest extends TestBase {
                 new File(dst, TEST_FILE_NAME2));
         assertArrayEquals(contents2, dstContents2);
     }
+
+    @Test
+    public void downloadMultipleFilesCreatesDestDirAutomatically() throws Exception {
+        Download t = makeProjectAndTask();
+        t.src(Arrays.asList(makeSrc(TEST_FILE_NAME), makeSrc(TEST_FILE_NAME2)));
+
+        File dst = folder.newFolder();
+        assertTrue(dst.delete());
+        t.dest(dst);
+        t.execute();
+        assertTrue(dst.isDirectory());
+    }
     
     /**
      * Tests if the task throws an exception if you try to download
@@ -205,5 +217,39 @@ public class DownloadTest extends TestBase {
         // contents must not be changed
         byte[] dstContents = FileUtils.readFileToByteArray(dst);
         assertArrayEquals("Hello".getBytes(), dstContents);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidSrc() throws Exception {
+        Download t = makeProjectAndTask();
+        t.src(new Object());
+    }
+
+    @Test(expected = TaskExecutionException.class)
+    public void testExecuteEmptySrc() throws Exception {
+        Download t = makeProjectAndTask();
+        t.execute();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidDest() throws Exception {
+        Download t = makeProjectAndTask();
+        t.dest(new Object());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExecuteEmptyDest() throws Exception {
+        Download t = makeProjectAndTask();
+        String src = makeSrc(TEST_FILE_NAME);
+        t.src(src);
+        t.execute();
+    }
+
+    @Test
+    public void testArraySrc() throws Exception {
+        Download t = makeProjectAndTask();
+        String src = makeSrc(TEST_FILE_NAME);
+        t.src(new Object[] { src });
+        assertTrue(t.getSrc() instanceof URL);
     }
 }

--- a/src/test/java/de/undercouch/gradle/tasks/download/FunctionalDownloadTest.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/FunctionalDownloadTest.java
@@ -168,8 +168,8 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
     }
 
     @Test
-    public void fileDependenciesTriggersDownload() throws Exception {
-        assertTaskSuccess(runTask(":processFiles", new Parameters(singleSrc, dest, true, false)));
+    public void fileDependenciesTriggersDownloadTask() throws Exception {
+        assertTaskSuccess(runTask(":processTask", new Parameters(singleSrc, dest, true, false)));
         assertTrue(destFile.exists());
     }
 
@@ -180,7 +180,7 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
      * @throws Exception if anything went wrong
      */
     protected BuildTask download(Parameters parameters) throws Exception {
-        return runTask(":download", parameters);
+        return runTask(":downloadTask", parameters);
     }
 
     /**
@@ -205,7 +205,7 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
     protected GradleRunner createRunner(Parameters parameters) throws IOException {
         return createRunnerWithBuildFile(
             "plugins { id 'de.undercouch.download' }\n" +
-            "task download(type: de.undercouch.gradle.tasks.download.Download) { \n" +
+            "task downloadTask(type: de.undercouch.gradle.tasks.download.Download) { \n" +
                 "src(" + parameters.src + ")\n" +
                 "dest " + parameters.dest + "\n" +
                 "overwrite " + Boolean.toString(parameters.overwrite) + "\n" +
@@ -213,11 +213,8 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
                 "compress " + Boolean.toString(parameters.compress) + "\n" +
                 "quiet " + Boolean.toString(parameters.quiet) + "\n" +
             "}\n" +
-            "task processFiles {\n" +
-                "inputs.files files(download)\n" +
-                 "doLast {\n" +
-                    "print(inputs.files)\n" +
-                 "}\n" +
+            "task processTask {\n" +
+                "inputs.files downloadTask\n" +
             "}\n", false);
     }
 

--- a/src/test/java/de/undercouch/gradle/tasks/download/FunctionalDownloadTest.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/FunctionalDownloadTest.java
@@ -21,7 +21,11 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -54,7 +58,18 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
      */
     @Test
     public void downloadSingleFile() throws Exception {
-        assertTaskSuccess(download(singleSrc, dest, true, false));
+        assertTaskSuccess(download(new Parameters(singleSrc, dest, true, false)));
+        assertTrue(destFile.exists());
+        assertArrayEquals(contents, FileUtils.readFileToByteArray(destFile));
+    }
+
+    /**
+     * Test if a single file can be downloaded successfully with quiet mode
+     * @throws Exception if anything went wrong
+     */
+    @Test
+    public void downloadSingleFileWithQuietMode() throws Exception {
+        assertTaskSuccess(download(new Parameters(singleSrc, dest, true, false, false, true)));
         assertTrue(destFile.exists());
         assertArrayEquals(contents, FileUtils.readFileToByteArray(destFile));
     }
@@ -65,7 +80,7 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
      */
     @Test
     public void downloadMultipleFiles() throws Exception {
-        assertTaskSuccess(download(multipleSrc, dest, true, false));
+        assertTaskSuccess(download(new Parameters(multipleSrc, dest, true, false)));
         assertTrue(destFile.isDirectory());
         assertArrayEquals(contents, FileUtils.readFileToByteArray(
                 new File(destFile, TEST_FILE_NAME)));
@@ -79,8 +94,9 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
      */
     @Test
     public void downloadSingleFileTwiceMarksTaskAsUpToDate() throws Exception {
-        assertTaskSuccess(download(singleSrc, dest, false, false));
-        assertTaskUpToDate(download(singleSrc, dest, false, false));
+        final Parameters parameters = new Parameters(singleSrc, dest, false, false);
+        assertTaskSuccess(download(parameters));
+        assertTaskUpToDate(download(parameters));
     }
 
     /**
@@ -89,8 +105,8 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
      */
     @Test
     public void downloadSingleFileTwiceWithOverwriteExecutesTwice() throws Exception {
-        assertTaskSuccess(download(singleSrc, dest, false, false));
-        assertTaskSuccess(download(singleSrc, dest, true, false));
+        assertTaskSuccess(download(new Parameters(singleSrc, dest, false, false)));
+        assertTaskSuccess(download(new Parameters(singleSrc, dest, true, false)));
     }
 
     /**
@@ -100,8 +116,8 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
      */
     @Test
     public void downloadSingleFileTwiceWithOfflineMode() throws Exception {
-        assertTaskSuccess(download(singleSrc, dest, false, false));
-        assertTaskSkipped(downloadOffline(singleSrc, dest, true, false));
+        assertTaskSuccess(download(new Parameters(singleSrc, dest, false, false)));
+        assertTaskSkipped(download(new Parameters(singleSrc, dest, true, false, true, false)));
     }
 
     /**
@@ -110,8 +126,8 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
      */
     @Test
     public void downloadOnlyIfNewer() throws Exception {
-        assertTaskSuccess(download(singleSrc, dest, false, false));
-        assertTaskUpToDate(download(singleSrc, dest, true, true));
+        assertTaskSuccess(download(new Parameters(singleSrc, dest, false, false)));
+        assertTaskUpToDate(download(new Parameters(singleSrc, dest, true, true)));
     }
 
     /**
@@ -121,10 +137,10 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
      */
     @Test
     public void downloadOnlyIfNewerRedownloadsIfFileHasBeenUpdated() throws Exception {
-        assertTaskSuccess(download(singleSrc, dest, false, false));
+        assertTaskSuccess(download(new Parameters(singleSrc, dest, false, false)));
         File src = new File(folder.getRoot(), TEST_FILE_NAME);
         assertTrue(src.setLastModified(src.lastModified() + 5000));
-        assertTaskSuccess(download(singleSrc, dest, true, true));
+        assertTaskSuccess(download(new Parameters(singleSrc, dest, true, true)));
     }
 
     /**
@@ -136,61 +152,59 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
         File testFile = new File(folder.getRoot(), TEST_FILE_NAME);
         FileUtils.writeByteArrayToFile(destFile, contents);
         assertTrue(destFile.setLastModified(testFile.lastModified()));
-        assertTaskSuccess(download(singleSrc, dest, true, false));
+        assertTaskSuccess(download(new Parameters(singleSrc, dest, true, false)));
     }
 
     /**
      * Create a download task
-     * @param src the src from which to download
-     * @param dest the destination file
-     * @param overwrite true if the overwrite flag should be set
-     * @param onlyIfNewer true if the onlyIfNewer flag should be set
+     * @param parameters the download parameters
      * @return the download task
      * @throws Exception if anything went wrong
      */
-    protected BuildTask download(String src, String dest, boolean overwrite,
-            boolean onlyIfNewer) throws Exception {
-        return createRunner(src, dest, overwrite, onlyIfNewer)
-            .withArguments("download")
-            .build()
-            .task(":download");
-    }
-
-    /**
-     * Create a download task in offline mode
-     * @param src the src from which to download
-     * @param dest the destination file
-     * @param overwrite true if the overwrite flag should be set
-     * @param onlyIfNewer true if the onlyIfNewer flag should be set
-     * @return the download task
-     * @throws IOException if anything went wrong
-     */
-    protected BuildTask downloadOffline(String src, String dest, boolean overwrite,
-            boolean onlyIfNewer) throws IOException {
-        return createRunner(src, dest, overwrite, onlyIfNewer)
-            .withArguments("--offline", "download")
+    protected BuildTask download(Parameters parameters) throws Exception {
+        return createRunner(parameters)
+            .withArguments(parameters.offline ? asList("--offline", "download") : singletonList("download"))
             .build()
             .task(":download");
     }
 
     /**
      * Create a gradle runner to test against
-     * @param src the src from which to download
-     * @param dest the destination file
-     * @param overwrite true if the overwrite flag should be set
-     * @param onlyIfNewer true if the onlyIfNewer flag should be set
+     * @param parameters the download parameters
      * @return the runner
      * @throws IOException if the build file could not be created
      */
-    protected GradleRunner createRunner(String src, String dest, boolean overwrite,
-            boolean onlyIfNewer) throws IOException {
+    protected GradleRunner createRunner(Parameters parameters) throws IOException {
         return createRunnerWithBuildFile(
             "plugins { id 'de.undercouch.download' }\n" +
             "task download(type: de.undercouch.gradle.tasks.download.Download) { \n" +
-                "src(" + src + ")\n" +
-                "dest " + dest + "\n" +
-                "overwrite " + Boolean.toString(overwrite) + "\n" +
-                "onlyIfNewer " + Boolean.toString(onlyIfNewer) + "\n" +
+                "src(" + parameters.src + ")\n" +
+                "dest " + parameters.dest + "\n" +
+                "overwrite " + Boolean.toString(parameters.overwrite) + "\n" +
+                "onlyIfNewer " + Boolean.toString(parameters.onlyIfNewer) + "\n" +
+                "quiet " + Boolean.toString(parameters.quiet) + "\n" +
             "}\n", false);
+    }
+
+    private static class Parameters {
+        final String src;
+        final String dest;
+        final boolean overwrite;
+        final boolean onlyIfNewer;
+        final boolean quiet;
+        final boolean offline;
+
+        Parameters(String src, String dest, boolean overwrite, boolean onlyIfNewer) {
+            this(src, dest, overwrite, onlyIfNewer, false, false);
+        }
+
+        Parameters(String src, String dest, boolean overwrite, boolean onlyIfNewer, boolean offline, boolean quiet) {
+            this.src = src;
+            this.dest = dest;
+            this.overwrite = overwrite;
+            this.onlyIfNewer = onlyIfNewer;
+            this.offline = offline;
+            this.quiet = quiet;
+        }
     }
 }

--- a/src/test/java/de/undercouch/gradle/tasks/download/FunctionalDownloadTest.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/FunctionalDownloadTest.java
@@ -69,7 +69,18 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
      */
     @Test
     public void downloadSingleFileWithQuietMode() throws Exception {
-        assertTaskSuccess(download(new Parameters(singleSrc, dest, true, false, false, true)));
+        assertTaskSuccess(download(new Parameters(singleSrc, dest, true, false, true, false, true)));
+        assertTrue(destFile.exists());
+        assertArrayEquals(contents, FileUtils.readFileToByteArray(destFile));
+    }
+
+    /**
+     * Test if a single file can be downloaded successfully with quiet mode
+     * @throws Exception if anything went wrong
+     */
+    @Test
+    public void downloadSingleFileWithoutCompress() throws Exception {
+        assertTaskSuccess(download(new Parameters(singleSrc, dest, true, false, false, false, false)));
         assertTrue(destFile.exists());
         assertArrayEquals(contents, FileUtils.readFileToByteArray(destFile));
     }
@@ -117,7 +128,7 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
     @Test
     public void downloadSingleFileTwiceWithOfflineMode() throws Exception {
         assertTaskSuccess(download(new Parameters(singleSrc, dest, false, false)));
-        assertTaskSkipped(download(new Parameters(singleSrc, dest, true, false, true, false)));
+        assertTaskSkipped(download(new Parameters(singleSrc, dest, true, false, true, true, false)));
     }
 
     /**
@@ -182,6 +193,7 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
                 "dest " + parameters.dest + "\n" +
                 "overwrite " + Boolean.toString(parameters.overwrite) + "\n" +
                 "onlyIfNewer " + Boolean.toString(parameters.onlyIfNewer) + "\n" +
+                "compress " + Boolean.toString(parameters.compress) + "\n" +
                 "quiet " + Boolean.toString(parameters.quiet) + "\n" +
             "}\n", false);
     }
@@ -191,18 +203,20 @@ public class FunctionalDownloadTest extends FunctionalTestBase {
         final String dest;
         final boolean overwrite;
         final boolean onlyIfNewer;
+        final boolean compress;
         final boolean quiet;
         final boolean offline;
 
         Parameters(String src, String dest, boolean overwrite, boolean onlyIfNewer) {
-            this(src, dest, overwrite, onlyIfNewer, false, false);
+            this(src, dest, overwrite, onlyIfNewer, true, false, false);
         }
 
-        Parameters(String src, String dest, boolean overwrite, boolean onlyIfNewer, boolean offline, boolean quiet) {
+        Parameters(String src, String dest, boolean overwrite, boolean onlyIfNewer, boolean compress, boolean offline, boolean quiet) {
             this.src = src;
             this.dest = dest;
             this.overwrite = overwrite;
             this.onlyIfNewer = onlyIfNewer;
+            this.compress = compress;
             this.offline = offline;
             this.quiet = quiet;
         }

--- a/src/test/java/de/undercouch/gradle/tasks/download/FunctionalTestBase.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/FunctionalTestBase.java
@@ -28,6 +28,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SKIPPED;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Base class for functional tests
@@ -72,6 +73,7 @@ public abstract class FunctionalTestBase extends TestBase {
      * @param task the task
      */
     protected void assertTaskSuccess(BuildTask task) {
+        assertNotNull("task is null", task);
         assertEquals("task " + task + " state should be success", SUCCESS, task.getOutcome());
     }
 
@@ -80,6 +82,7 @@ public abstract class FunctionalTestBase extends TestBase {
      * @param task the task
      */
     protected void assertTaskUpToDate(BuildTask task) {
+        assertNotNull("task is null", task);
         assertEquals("task " + task + " state should be up-to-date", UP_TO_DATE, task.getOutcome());
     }
 
@@ -88,6 +91,7 @@ public abstract class FunctionalTestBase extends TestBase {
      * @param task the task
      */
     protected void assertTaskSkipped(BuildTask task) {
+        assertNotNull("task is null", task);
         assertEquals("task " + task + " state should be skipped", SKIPPED, task.getOutcome());
     }
 

--- a/src/test/java/de/undercouch/gradle/tasks/download/OutputsTest.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/OutputsTest.java
@@ -1,0 +1,47 @@
+package de.undercouch.gradle.tasks.download;
+
+import org.gradle.api.file.FileCollection;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class OutputsTest extends TestBase {
+
+    @Test
+    public void emptyOutputs() throws Exception {
+        Download t = makeProjectAndTask();
+        assertTrue(t.getOutputs().getFiles().isEmpty());
+    }
+
+    @Test
+    public void singleOutputFileWithDestinationFile() throws Exception {
+        Download t = makeProjectAndTask();
+        t.src(makeSrc(TEST_FILE_NAME));
+        File dst = folder.newFile();
+        t.dest(dst);
+        assertEquals(dst, t.getOutputs().getFiles().getSingleFile());
+    }
+
+    @Test
+    public void singleOutputFileWithDestinationDirectory() throws Exception {
+        Download t = makeProjectAndTask();
+        t.src(makeSrc(TEST_FILE_NAME));
+        t.dest(folder.getRoot());
+        assertEquals(new File(folder.getRoot(), TEST_FILE_NAME), t.getOutputs().getFiles().getSingleFile());
+    }
+
+    @Test
+    public void multipleOutputFiles() throws Exception {
+        Download t = makeProjectAndTask();
+        t.src(Arrays.asList(makeSrc(TEST_FILE_NAME), makeSrc(TEST_FILE_NAME2)));
+        t.dest(folder.getRoot());
+        final FileCollection fileCollection = t.getOutputs().getFiles();
+        assertEquals(2, fileCollection.getFiles().size());
+        assertTrue(fileCollection.contains(new File(folder.getRoot(), TEST_FILE_NAME)));
+        assertTrue(fileCollection.contains(new File(folder.getRoot(), TEST_FILE_NAME2)));
+    }
+}


### PR DESCRIPTION
This allows task chaining in the form of:

```gradle
task downloadFiles(type: Download)  {
  src(["http://foo.com/1", "http://foo.com/2"])
  dest(file('downloads'))
}

task processFiles {
  inputs.files downloadFiles
}
```