### PR TITLE
Add functional download tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id "com.gradle.plugin-publish" version "0.9.4"
 }
 
-apply plugin: 'java'
+apply plugin: 'java-gradle-plugin'
 apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'

--- a/src/main/java/de/undercouch/gradle/tasks/download/Download.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/Download.java
@@ -58,7 +58,7 @@ public class Download extends DefaultTask implements DownloadSpec {
                 //as much compatibility to previous Gradle versions as possible (see issue #16)
                 Method getState = this.getClass().getMethod("getState");
                 Object state = getState.invoke(this);
-                Method skipped = state.getClass().getMethod("skipped");
+                Method skipped = state.getClass().getMethod("skipped", String.class);
                 if (skipped != null) {
                     skipped.invoke(state, "Download skipped");
                 }

--- a/src/test/java/de/undercouch/gradle/tasks/download/FunctionalDownloadTest.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/FunctionalDownloadTest.java
@@ -1,0 +1,87 @@
+package de.undercouch.gradle.tasks.download;
+
+import org.apache.commons.io.FileUtils;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FunctionalDownloadTest extends FunctionalTestBase {
+    private String singleSrc;
+    private String multipleSrc;
+    private String dest;
+    private File destFile;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        singleSrc = "'" + makeSrc(TEST_FILE_NAME) + "'";
+        multipleSrc = "['" +  makeSrc(TEST_FILE_NAME) + "', '" + makeSrc(TEST_FILE_NAME2) + "']";
+        destFile = new File(testProjectDir.getRoot(), "someFile");
+        dest = "file('"+destFile.getName()+"')";
+    }
+
+    @Test
+    public void downloadSingleFile() throws Exception {
+        assertTaskSuccess(download(singleSrc, dest, true));
+        assertTrue(destFile.exists());
+        assertArrayEquals(contents, FileUtils.readFileToByteArray(destFile));
+    }
+
+    @Test
+    public void downloadMultipleFiles() throws Exception {
+        assertTaskSuccess(download(multipleSrc, dest, true));
+        assertTrue(destFile.isDirectory());
+        assertArrayEquals(contents, FileUtils.readFileToByteArray(
+                new File(destFile, TEST_FILE_NAME)));
+        assertArrayEquals(contents2, FileUtils.readFileToByteArray(
+                new File(destFile, TEST_FILE_NAME2)));
+    }
+
+    @Test
+    public void downloadSingleFileTwiceMarksTaskAsUpToDate() throws Exception {
+        assertTaskSuccess(download(singleSrc, dest, false));
+        assertTaskUpToDate(download(singleSrc, dest, false));
+    }
+
+    @Test
+    public void downloadSingleFileTwiceWithOverwriteExecutesTwice() throws Exception {
+        assertTaskSuccess(download(singleSrc, dest, false));
+        assertTaskSuccess(download(singleSrc, dest, true));
+    }
+
+    @Test
+    public void downloadSingleFileTwiceWithOfflineMode() throws Exception {
+        assertTaskSuccess(download(singleSrc, dest, false));
+        assertTaskSkipped(downloadOffline(singleSrc, dest, true));
+    }
+
+    protected BuildTask download(String src, String dest, boolean overwrite) throws Exception {
+        return createRunner(src, dest, overwrite, false)
+            .withArguments("download")
+            .build()
+            .task(":download");
+    }
+
+    protected BuildTask downloadOffline(String src, String dest, boolean overwrite) throws Exception {
+        return createRunner(src, dest, overwrite, false)
+            .withArguments("--offline", "download")
+            .build()
+            .task(":download");
+    }
+
+    protected GradleRunner createRunner(String src, String dest, boolean overwrite, boolean onlyIfNewer) throws Exception {
+        return createRunnerWithBuildFile(
+            "plugins { id 'de.undercouch.download' }\n" +
+            "task download(type: de.undercouch.gradle.tasks.download.Download) { \n" +
+                "src(" + src + ")\n" +
+                "dest " + dest + "\n" +
+                "overwrite " + Boolean.toString(overwrite) + "\n" +
+                "onlyIfNewer " + Boolean.toString(onlyIfNewer) + "\n" +
+            "}\n");
+    }
+}

--- a/src/test/java/de/undercouch/gradle/tasks/download/FunctionalTestBase.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/FunctionalTestBase.java
@@ -1,0 +1,59 @@
+package de.undercouch.gradle.tasks.download;
+
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static org.gradle.testkit.runner.TaskOutcome.SKIPPED;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE;
+import static org.junit.Assert.assertEquals;
+
+public abstract class FunctionalTestBase extends TestBase {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private File buildFile;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        buildFile = testProjectDir.newFile("build.gradle");
+    }
+
+    protected GradleRunner createRunnerWithBuildFile(String buildFile) throws IOException {
+        writeBuildFile(buildFile);
+        return GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(testProjectDir.getRoot());
+    }
+
+    protected void assertTaskSuccess(BuildTask task) {
+        assertEquals("task "+task+" state should be success", SUCCESS, task.getOutcome());
+    }
+
+    protected void assertTaskUpToDate(BuildTask task) {
+        assertEquals("task "+task+" state should be up-to-date", UP_TO_DATE, task.getOutcome());
+    }
+
+    protected void assertTaskSkipped(BuildTask task) {
+        assertEquals("task "+task+" state should be skipped", SKIPPED, task.getOutcome());
+    }
+
+    private void writeBuildFile(String content) throws IOException {
+        BufferedWriter output = null;
+        try {
+            output = new BufferedWriter(new FileWriter(buildFile));
+            output.write(content);
+        } finally {
+            if (output != null) {
+                output.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
I picked up work on #43 again and noticed that there's no test coverage for the skipped / uptodate logic, which need to be added first. The tests also revealed a problem with the current skipped logic.