### PR TITLE
NTLM authentication support added

### DIFF
--- a/src/main/java/de/undercouch/gradle/tasks/download/Download.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/Download.java
@@ -134,6 +134,21 @@ public class Download extends DefaultTask implements DownloadSpec {
     }
 
     @Override
+    public void authType(String authType) {
+        action.authType(authType);
+    }
+
+    @Override
+    public void workstation(String workstation) {
+        action.workstation(workstation);
+    }
+
+    @Override
+    public void domain(String domain) {
+        action.domain(domain);
+    }
+
+    @Override
     public void headers(Map<String, String> headers) {
         action.headers(headers);
     }

--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
@@ -86,8 +86,6 @@ public class DownloadAction implements DownloadSpec {
     private static final HostnameVerifier INSECURE_HOSTNAME_VERIFIER = new InsecureHostnameVerifier();
     private static final TrustManager[] INSECURE_TRUST_MANAGERS = { new InsecureTrustManager() };
 
-    private static final String BASIC_AUTH_TYPE = "Basic";
-    private static final String NTLM_AUTH_TYPE = "NTLM";
     private static final String DEFAULT_AUTH_TYPE = BASIC_AUTH_TYPE;
 
     private static final Set<String> VALID_AUTH_TYPES = new HashSet<String>(){

--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
@@ -28,9 +28,12 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.zip.GZIPInputStream;
 
 import javax.net.ssl.HostnameVerifier;
@@ -42,7 +45,10 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScheme;
 import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.NTCredentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthCache;
 import org.apache.http.client.ClientProtocolException;
@@ -58,6 +64,7 @@ import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.auth.NTLMScheme;
 import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -78,6 +85,17 @@ import groovy.lang.Closure;
 public class DownloadAction implements DownloadSpec {
     private static final HostnameVerifier INSECURE_HOSTNAME_VERIFIER = new InsecureHostnameVerifier();
     private static final TrustManager[] INSECURE_TRUST_MANAGERS = { new InsecureTrustManager() };
+
+    private static final String BASIC_AUTH_TYPE = "Basic";
+    private static final String NTLM_AUTH_TYPE = "NTLM";
+    private static final String DEFAULT_AUTH_TYPE = BASIC_AUTH_TYPE;
+
+    private static final Set<String> VALID_AUTH_TYPES = new HashSet<String>(){
+        {
+            add(BASIC_AUTH_TYPE);
+            add(NTLM_AUTH_TYPE);
+        }
+    };
     
     private final Project project;
     private List<URL> sources = new ArrayList<URL>(1);
@@ -88,6 +106,9 @@ public class DownloadAction implements DownloadSpec {
     private boolean compress = true;
     private String username;
     private String password;
+    private String workstation;
+    private String domain;
+    private String authType = DEFAULT_AUTH_TYPE;
     private Map<String, String> headers;
     private boolean acceptAnyCertificate = false;
 
@@ -383,9 +404,23 @@ public class DownloadAction implements DownloadSpec {
         HttpClientContext context = null;
         if (username != null && password != null) {
             context = HttpClientContext.create();
-            addAuthentication(httpHost, username, password, true, context);
+
+            Credentials credentials;
+            AuthScheme authScheme;
+
+            if (NTLM_AUTH_TYPE.equals(authType)) {
+                credentials = new NTCredentials(username, password, workstation, domain);
+                authScheme = new NTLMScheme();
+            } else if (BASIC_AUTH_TYPE.equals(authType)) {
+                credentials = new UsernamePasswordCredentials(username, password);
+                authScheme = new BasicScheme();
+            } else {
+                throw new IllegalStateException("Internal plugin error. Usage of not supported authType: " + authType);
+            }
+
+            addAuthentication(httpHost, credentials, authScheme, context);
         }
-        
+
         //create request
         HttpGet get = new HttpGet(file);
         
@@ -405,7 +440,8 @@ public class DownloadAction implements DownloadSpec {
                 if (context == null) {
                     context = HttpClientContext.create();
                 }
-                addAuthentication(proxy, proxyUser, proxyPassword, false, context);
+                Credentials credentials = new UsernamePasswordCredentials(proxyUser, proxyPassword);
+                addAuthentication(proxy, credentials, null, context);
             }
         }
         
@@ -441,16 +477,15 @@ public class DownloadAction implements DownloadSpec {
     /**
      * Add authentication information for the given host
      * @param host the host
-     * @param username the username
-     * @param password the password
-     * @param preAuthenticate <code>true</code> if the authentication scheme
-     * should be set to <code>Basic</code> preemptively (should be
-     * <code>false</code> if adding authentication for a proxy server)
+     * @param credentials credentials for given authentication type
+     * @param preAuthScheme <code>not null</code> if the authentication scheme
+     * should be set preemptively (should be
+     * <code>null</code> if adding authentication for a proxy server)
      * @param context the context in which the authentication information
      * should be saved
      */
-    private void addAuthentication(HttpHost host, String username,
-            String password, boolean preAuthenticate, HttpClientContext context) {
+    private void addAuthentication(HttpHost host, Credentials credentials, AuthScheme preAuthScheme,
+                                   HttpClientContext context) {
         AuthCache authCache = context.getAuthCache();
         if (authCache == null) {
             authCache = new BasicAuthCache();
@@ -463,11 +498,10 @@ public class DownloadAction implements DownloadSpec {
             context.setCredentialsProvider(credsProvider);
         }
         
-        credsProvider.setCredentials(new AuthScope(host),
-                new UsernamePasswordCredentials(username, password));
+        credsProvider.setCredentials(new AuthScope(host), credentials);
         
-        if (preAuthenticate) {
-            authCache.put(host, new BasicScheme());
+        if (preAuthScheme != null) {
+            authCache.put(host, preAuthScheme);
         }
     }
     
@@ -655,6 +689,40 @@ public class DownloadAction implements DownloadSpec {
     @Override
     public void password(String password) {
         this.password = password;
+    }
+
+    @Override
+    public void authType(String authType) {
+        if (authType == null) {
+            this.authType = DEFAULT_AUTH_TYPE;
+        } else if (VALID_AUTH_TYPES.contains(authType)) {
+            this.authType = authType;
+        } else {
+            assertInvalidAuthType(authType);
+        }
+    }
+
+    private void assertInvalidAuthType(String authType) {
+        StringBuilder builder = new StringBuilder("Authentication type: ");
+        builder.append(authType).append(" is not supported. Use one of: [ ");
+        for (Iterator<String> iterator = VALID_AUTH_TYPES.iterator(); iterator.hasNext();) {
+            String type = iterator.next();
+            builder.append(type);
+
+            if (iterator.hasNext()) {
+                builder.append(", ");
+            }
+        }
+        builder.append(" ]");
+        throw new IllegalArgumentException(builder.toString());
+    }
+
+    public void domain(String domain) {
+        this.domain = domain;
+    }
+
+    public void workstation(String workstation) {
+        this.workstation = workstation;
     }
 
     @Override

--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadSpec.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadSpec.java
@@ -62,16 +62,36 @@ public interface DownloadSpec {
     void compress(boolean compress);
     
     /**
-     * Sets the username for <code>Basic</code> authentication
+     * Sets the username for <code>Basic</code> and <code>NTLM</code> authentication
      * @param username the username
      */
     void username(String username);
     
     /**
-     * Sets the password for <code>Basic</code> authentication
+     * Sets the password for <code>Basic</code> and <code>NTLM</code> authentication
      * @param password the password
      */
     void password(String password);
+
+    /**
+     * Specifies authentication type to be used.
+     * Currently valid values are <code>Basic</code> and <code>NTLM</code>
+     *
+     * @param authType the authType, default is <code>Basic</code>
+     */
+    void authType(String authType);
+
+    /**
+     * Sets the domain for <code>NTLM</code> authentication
+     * @param domain the domain
+     */
+    void domain(String domain);
+
+    /**
+     * Sets the workstation for <code>NTLM</code> authentication
+     * @param workstation the workstation
+     */
+    void workstation(String workstation);
 
     /**
      * Sets the HTTP request headers to us when downloading

--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadSpec.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadSpec.java
@@ -23,6 +23,17 @@ import java.util.Map;
  * @author Michel Kraemer
  */
 public interface DownloadSpec {
+
+    /**
+     * <code>Basic</code> authType constant
+     */
+    String BASIC_AUTH_TYPE = "Basic";
+
+    /**
+     * <code>Basic</code> authType constant
+     */
+    String NTLM_AUTH_TYPE = "NTLM";
+
     /**
      * Sets the download source URL
      * @param src the URL

--- a/src/test/java/de/undercouch/gradle/tasks/download/AuthenticationTest.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/AuthenticationTest.java
@@ -39,7 +39,8 @@ public class AuthenticationTest extends TestBase {
     private static final String PASSWORD = "testpass456";
     private static final String USERNAME = "testuser123";
     private static final String AUTHENTICATE = "authenticate";
-    
+    public static final String INVALID_AUTHENTICATION_TYPE = "Invalid Authentication";
+
     @Override
     protected Handler[] makeHandlers() throws IOException {
         ContextHandler authenticationHandler = new ContextHandler("/" + AUTHENTICATE) {
@@ -55,7 +56,7 @@ public class AuthenticationTest extends TestBase {
                 }
                 if (!ahdr.startsWith("Basic ")) {
                     response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
-                            "Authorization header does not start with 'Basic '");
+                            "Authorization header does not start with 'Basic '" + ahdr);
                     return;
                 }
                 
@@ -100,6 +101,22 @@ public class AuthenticationTest extends TestBase {
         t.src(makeSrc(AUTHENTICATE));
         File dst = folder.newFile();
         t.dest(dst);
+        t.username(USERNAME + "!");
+        t.password(PASSWORD + "!");
+        t.execute();
+    }
+
+    /**
+     * Tests if the plugin doesn't accept invalid authentication type
+     * @throws Exception if anything goes wrong
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidAuthType() throws Exception {
+        Download t = makeProjectAndTask();
+        t.src(makeSrc(AUTHENTICATE));
+        File dst = folder.newFile();
+        t.dest(dst);
+        t.authType(INVALID_AUTHENTICATION_TYPE);
         t.username(USERNAME + "!");
         t.password(PASSWORD + "!");
         t.execute();


### PR DESCRIPTION
We need to have a support for NTLM authentication capability as our servers doesn't support basic authentication.

Here is NTLM authentication support added.
It should be easy to add any additional authentication type using the same approach.

currently proxy NTLM is not supported as it's uncommon for proxies

could be easily extended if someone would need it for proxy as well