### PR TITLE
Respect http.nonProxyHosts

### DIFF
--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
@@ -41,7 +41,6 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthCache;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.protocol.HttpClientContext;
@@ -287,40 +286,6 @@ public class DownloadAction implements DownloadSpec {
     }
     
     /**
-     * Configure proxy for a given HTTP host
-     * @param httpHost the HTTP host
-     * @return the proxy or <code>null</code> if not proxy is necessary
-     * @throws IOException if the proxy could not be configured
-     */
-    private HttpHost configureProxy(HttpHost httpHost) throws IOException {
-        HttpHost proxy = null;
-        
-        String scheme = httpHost.getSchemeName();
-        if (!"http".equals(scheme) && !"https".equals(scheme) &&
-                !"ftp".equals(scheme)) {
-            return proxy;
-        }
-        
-        String host = System.getProperty(scheme + ".proxyHost");
-        if (host != null) {
-            String portStr = System.getProperty(scheme + ".proxyPort");
-            if (portStr != null) {
-                int port;
-                try {
-                    port = Integer.parseInt(portStr);
-                } catch (NumberFormatException e) {
-                    throw new IllegalArgumentException("Illegal proxy port: " + portStr);
-                }
-                proxy = new HttpHost(host, port);
-            } else {
-                proxy = new HttpHost(host);
-            }
-        }
-        
-        return proxy;
-    }
-    
-    /**
      * Opens a connection to the given HTTP host and requests a file. Checks
      * the last-modified header on the server if the given timestamp is
      * greater than 0.
@@ -358,26 +323,21 @@ public class DownloadAction implements DownloadSpec {
         //create request
         HttpGet get = new HttpGet(file);
         
-        //configure proxy
-        HttpHost proxy = configureProxy(httpHost);
-        if (proxy != null) {
-            RequestConfig config = RequestConfig.custom()
-                .setProxy(proxy)
-                .build();
-            get.setConfig(config);
-            
-            //add authentication information for proxy
-            String scheme = httpHost.getSchemeName();
-            String proxyUser = System.getProperty(scheme + ".proxyUser");
-            String proxyPassword = System.getProperty(scheme + ".proxyPassword");
-            if (proxyUser != null && proxyPassword != null) {
-                if (context == null) {
-                    context = HttpClientContext.create();
-                }
-                Credentials credentials =
-                        new UsernamePasswordCredentials(proxyUser, proxyPassword);
-                addAuthentication(proxy, credentials, null, context);
+        //add authentication information for proxy
+        String scheme = httpHost.getSchemeName();
+        String proxyHost = System.getProperty(scheme + ".proxyHost");
+        String proxyPort = System.getProperty(scheme + ".proxyPort");
+        String proxyUser = System.getProperty(scheme + ".proxyUser");
+        String proxyPassword = System.getProperty(scheme + ".proxyPassword");
+        if (proxyHost != null && proxyPort != null && proxyUser != null && proxyPassword != null) {
+            if (context == null) {
+                context = HttpClientContext.create();
             }
+            HttpHost proxy = 
+                    new HttpHost(proxyHost, Integer.parseInt(proxyPort), scheme);
+            Credentials credentials =
+                    new UsernamePasswordCredentials(proxyUser, proxyPassword);
+            addAuthentication(proxy, credentials, null, context);
         }
         
         //set If-Modified-Since header

--- a/src/main/java/de/undercouch/gradle/tasks/download/internal/DefaultHttpClientFactory.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/internal/DefaultHttpClientFactory.java
@@ -31,6 +31,7 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 
 /**
  * Default implementation of {@link HttpClientFactory}. Creates a new client
@@ -50,6 +51,8 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     public CloseableHttpClient createHttpClient(HttpHost httpHost,
             boolean acceptAnyCertificate) {
         HttpClientBuilder builder = HttpClientBuilder.create();
+        
+        builder.setRoutePlanner(new SystemDefaultRoutePlanner(null));
         
         //accept any certificate if necessary
         if ("https".equals(httpHost.getSchemeName()) && acceptAnyCertificate) {

--- a/src/test/java/de/undercouch/gradle/tasks/download/DownloadTest.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/DownloadTest.java
@@ -177,7 +177,7 @@ public class DownloadTest extends TestBase {
             private static final long serialVersionUID = -4463658999363261400L;
             
             @SuppressWarnings("unused")
-            public Object doCall() {
+            public Object doCall() throws Exception {
                 srcCalled[0] = true;
                 return makeSrc(TEST_FILE_NAME);
             }

--- a/src/test/java/de/undercouch/gradle/tasks/download/ProxyTest.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/ProxyTest.java
@@ -128,9 +128,11 @@ public class ProxyTest extends TestBase {
     /**
      * Tests if a single file can be downloaded through a proxy server
      * @param authenticating true if the proxy should require authentication
+     * @param newNonProxyHosts new value of the "http.nonProxyHosts" system property
+     * @param expectedProxyCounter number of times the request is expected to hit the proxy
      * @throws Exception if anything goes wrong
      */
-    private void testProxy(boolean authenticating) throws Exception {
+    private void testProxy(boolean authenticating, String newNonProxyHosts, int expectedProxyCounter) throws Exception {
         String proxyHost = System.getProperty("http.proxyHost");
         String proxyPort = System.getProperty("http.proxyPort");
         String nonProxyHosts = System.getProperty("http.nonProxyHosts");
@@ -141,7 +143,10 @@ public class ProxyTest extends TestBase {
         try {
             System.setProperty("http.proxyHost", "127.0.0.1");
             System.setProperty("http.proxyPort", String.valueOf(this.proxyPort));
-            String newNonProxyHosts = findNonProxyHosts();
+            
+            if (newNonProxyHosts == null) {
+                newNonProxyHosts = findNonProxyHosts();
+            }
             if (newNonProxyHosts == null) {
                 System.err.println("Could not configure nonProxyHosts that "
                         + "bypasses localhost. Please use a newer JDK version "
@@ -164,7 +169,7 @@ public class ProxyTest extends TestBase {
             
             byte[] dstContents = FileUtils.readFileToByteArray(dst);
             assertArrayEquals(contents, dstContents);
-            assertEquals(1, proxyCounter);
+            assertEquals(expectedProxyCounter, proxyCounter);
         } finally {
             stopProxy();
             if (proxyHost == null) {
@@ -201,7 +206,7 @@ public class ProxyTest extends TestBase {
      */
     @Test
     public void normalProxy() throws Exception {
-        testProxy(false);
+        testProxy(false, null, 1);
     }
     
     /**
@@ -210,6 +215,15 @@ public class ProxyTest extends TestBase {
      */
     @Test
     public void authenticationProxy() throws Exception {
-        testProxy(true);
+        testProxy(true, null, 1);
+    }
+    
+    /**
+     * Tests if the "http.nonProxyHosts" system property is respected 
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    public void nonProxyHosts() throws Exception {
+        testProxy(false, "localhost", 0);
     }
 }

--- a/src/test/java/de/undercouch/gradle/tasks/download/ProxyTest.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/ProxyTest.java
@@ -16,14 +16,9 @@ package de.undercouch.gradle.tasks.download;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
-import java.net.Proxy;
-import java.net.ProxySelector;
-import java.net.URI;
-import java.util.List;
+import java.net.InetAddress;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
@@ -98,34 +93,6 @@ public class ProxyTest extends TestBase {
     }
     
     /**
-     * <p>Find a setting for the "http.nonProxyHosts" system property that does
-     * not bypass "localhost".</p>
-     * <p>See http://bugs.java.com/view_bug.do?bug_id=6737819</p>
-     * @return the new setting or <code>null</code> if no setting was found
-     * on the current JVM
-     * @throws Exception should never happen
-     */
-    private static String findNonProxyHosts() throws Exception {
-        URI u = new URI("http://localhost");
-        
-        System.setProperty("http.nonProxyHosts", "");
-        List<Proxy> l = ProxySelector.getDefault().select(u);
-        assertFalse(l.isEmpty());
-        if (l.get(0).type() != Proxy.Type.DIRECT) {
-            return "";
-        }
-        
-        System.setProperty("http.nonProxyHosts", "~localhost");
-        l = ProxySelector.getDefault().select(u);
-        assertFalse(l.isEmpty());
-        if (l.get(0).type() != Proxy.Type.DIRECT) {
-            return "~localhost";
-        }
-        
-        return null;
-    }
-    
-    /**
      * Tests if a single file can be downloaded through a proxy server
      * @param authenticating true if the proxy should require authentication
      * @param newNonProxyHosts new value of the "http.nonProxyHosts" system property
@@ -143,17 +110,6 @@ public class ProxyTest extends TestBase {
         try {
             System.setProperty("http.proxyHost", "127.0.0.1");
             System.setProperty("http.proxyPort", String.valueOf(this.proxyPort));
-            
-            if (newNonProxyHosts == null) {
-                newNonProxyHosts = findNonProxyHosts();
-            }
-            if (newNonProxyHosts == null) {
-                System.err.println("Could not configure nonProxyHosts that "
-                        + "bypasses localhost. Please use a newer JDK version "
-                        + "to run this test.");
-                assumeTrue(false);
-                return;
-            }
             System.setProperty("http.nonProxyHosts", newNonProxyHosts);
             
             if (authenticating) {
@@ -206,7 +162,7 @@ public class ProxyTest extends TestBase {
      */
     @Test
     public void normalProxy() throws Exception {
-        testProxy(false, null, 1);
+        testProxy(false, "", 1);
     }
     
     /**
@@ -215,7 +171,7 @@ public class ProxyTest extends TestBase {
      */
     @Test
     public void authenticationProxy() throws Exception {
-        testProxy(true, null, 1);
+        testProxy(true, "", 1);
     }
     
     /**
@@ -224,6 +180,7 @@ public class ProxyTest extends TestBase {
      */
     @Test
     public void nonProxyHosts() throws Exception {
-        testProxy(false, "localhost", 0);
+        testProxy(false, InetAddress.getLocalHost().getCanonicalHostName(), 0);
+        testProxy(false, "example.com", 1);
     }
 }

--- a/src/test/java/de/undercouch/gradle/tasks/download/TestBase.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/TestBase.java
@@ -16,7 +16,9 @@ package de.undercouch.gradle.tasks.download;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -186,8 +188,9 @@ public abstract class TestBase {
      * Makes a URL for a file provided by the embedded HTTP server
      * @param fileName the file's name
      * @return the URL
+     * @throws UnknownHostException 
      */
-    protected String makeSrc(String fileName) {
-        return "http://localhost:" + getServerPort() + "/" + fileName;
+    protected String makeSrc(String fileName) throws UnknownHostException {
+        return "http://" + InetAddress.getLocalHost().getCanonicalHostName() + ":" + getServerPort() + "/" + fileName;
     }
 }


### PR DESCRIPTION
Hi,
Sorry for the late reply, I've been very busy lately 😞

This is a follow-up for https://github.com/michel-kraemer/gradle-download-task/pull/63. What do you think of this approach? Instead of pointing to `localhost` or `localhost.localdomain`, I use the domain name of the local machine.