### PR TITLE
[WIP] Run functional tests against different versions of Gradle

### DIFF
--- a/src/test/java/de/undercouch/gradle/tasks/download/FunctionalTestBase.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/FunctionalTestBase.java
@@ -40,6 +40,12 @@ public abstract class FunctionalTestBase extends TestBase {
      */
     @Rule
     public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    /**
+     * The version of Gradle to run the test with, null for default.
+     */
+    protected String gradleVersion;
+
     private File buildFile;
 
     /**
@@ -62,10 +68,14 @@ public abstract class FunctionalTestBase extends TestBase {
     protected GradleRunner createRunnerWithBuildFile(String buildFile,
             boolean debug) throws IOException {
         writeBuildFile(buildFile);
-        return GradleRunner.create()
+        GradleRunner runner = GradleRunner.create()
             .withPluginClasspath()
             .withDebug(debug)
             .withProjectDir(testProjectDir.getRoot());
+        if (gradleVersion != null) {
+            runner = runner.withGradleVersion(gradleVersion);
+        }
+        return runner;
     }
 
     /**


### PR DESCRIPTION
There have been some breaking changes introduced in the Gradle 3.x series (haven't figured out exactly where yet).

It was never caught because the functional tests only run against 2.x.

@michel-kraemer is there any way the CI build can be triggered for PRs?