### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,13 @@ buildscript {
 }
 
 plugins {
+    id "com.gradle.build-scan" version "1.16"
     id "com.gradle.plugin-publish" version "0.9.9"
+}
+
+buildScan {
+  termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+  termsOfServiceAgree = 'yes'
 }
 
 apply plugin: 'java-gradle-plugin'


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.

If this PR is accepted then scan generation must be enabled on the command line, like so

    ./gradlew build -Dscan=true