### PR TITLE
Fix breaking change, add back constructor with one argument

### DIFF
--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
@@ -117,6 +117,14 @@ public class DownloadAction implements DownloadSpec {
     /**
      * Creates a new download action
      * @param project the project to be built
+     */
+    public DownloadAction(Project project) {
+        this(project, null);
+    }
+
+    /**
+     * Creates a new download action
+     * @param project the project to be built
      * @param task the task to be executed, if applicable
      */
     public DownloadAction(Project project, @Nullable Task task) {

--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadExtension.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadExtension.java
@@ -39,7 +39,7 @@ public class DownloadExtension implements Configurable<DownloadExtension> {
     
     @Override
     public DownloadExtension configure(Closure cl) {
-        DownloadAction da = ConfigureUtil.configure(cl, new DownloadAction(project, null));
+        DownloadAction da = ConfigureUtil.configure(cl, new DownloadAction(project));
         try {
             da.execute();
         } catch (IOException e) {


### PR DESCRIPTION
The version 4.1.0 had a non backwards compatible change by adding a second argument to the `DownloadAction` constructor.
This pull request adds back the constructor with one argument and passes `null` as task to the new constructor.

There are other plugins out there that used the old constructor and broke.
E.g.
- https://github.com/leontebbens/chromedriver-updater-plugin/blob/17a1129623ab0d4974eb4b2b08e6f8ab0a0a313e/src/main/groovy/eu/leontebbens/gradle/ChromedriverUpdaterTask.groovy#L103