### PR TITLE
Automated changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - someuser
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/BuildRelease.yml
+++ b/.github/workflows/BuildRelease.yml
@@ -1,0 +1,50 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: 8
+          distribution: zulu
+
+      - name: Find Tag
+        id: tagger
+        uses: jimschubert/query-tag-action@v2
+        with:
+          skip-unshallow: 'true'
+          abbrev: false
+          commit-ish: HEAD
+
+      - name: Check pre-release
+        run: |
+          echo "tag=${{steps.tagger.outputs.tag}}"
+          if [[ ${{ steps.tagger.outputs.tag }} == *alpha* || ${{ steps.tagger.outputs.tag }} == *beta* ]]
+          then
+             prerelease=true
+          else
+             prerelease=false
+          fi
+          echo "PRE_RELEASE=$prerelease" >> $GITHUB_ENV
+          echo "prerelease=$prerelease"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{steps.tagger.outputs.tag}}
+          generate_release_notes: true
+          prerelease: ${{ env.PRE_RELEASE }}
+          name: ${{steps.tagger.outputs.tag}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Thank you for the plugin and please consider to automate the change log.
With this, you can simply push a tag and that's it. 
When you 
* use alpha or beta in tag name, it's automated a pre-release
* with [labels](https://github.com/michel-kraemer/gradle-download-task/pull/262/files#diff-409fea45635f464aa0592700a92cf483be2f5b21b60f8f1b383756067ee79213R10) (or [this](https://github.com/michel-kraemer/gradle-download-task/pull/262/files#diff-409fea45635f464aa0592700a92cf483be2f5b21b60f8f1b383756067ee79213R13)) in pull request you can highlight some entries in change log

Here you see a working example https://github.com/gitx/gitx/releases/tag/0.21