### PR TITLE
Sanitize Location header URL to allow malformed redirection URL to be processed

### DIFF
--- a/src/main/java/de/undercouch/gradle/tasks/download/internal/DefaultHttpClientFactory.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/internal/DefaultHttpClientFactory.java
@@ -20,6 +20,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.impl.routing.SystemDefaultRoutePlanner;
+import org.apache.hc.client5.http.protocol.RedirectStrategy;
 import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
 import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
@@ -51,6 +52,9 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
         { new InsecureTrustManager() };
 
     private SSLConnectionSocketFactory insecureSSLSocketFactory = null;
+
+    private static final RedirectStrategy REDIRECT_STRATEGY =
+            new SanitizingLocationUriRedirectStrategy();
 
     @Override
     public CloseableHttpClient createHttpClient(HttpHost httpHost,
@@ -98,6 +102,8 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
         // add interceptor that strips the standard ports :80 and :443 from the
         // Host header unless the host has been explicitly specified by the user
         builder.addRequestInterceptorLast(new StripPortsFromHostInterceptor(headers));
+
+        builder.setRedirectStrategy(REDIRECT_STRATEGY);
 
         if (logger.isDebugEnabled()) {
             DebugInterceptor di = new DebugInterceptor();

--- a/src/main/java/de/undercouch/gradle/tasks/download/internal/SanitizingLocationUriRedirectStrategy.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/internal/SanitizingLocationUriRedirectStrategy.java
@@ -1,0 +1,34 @@
+package de.undercouch.gradle.tasks.download.internal;
+
+
+import org.apache.hc.client5.http.impl.DefaultRedirectStrategy;
+import org.apache.hc.core5.http.ProtocolException;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLDecoder;
+
+public class SanitizingLocationUriRedirectStrategy extends DefaultRedirectStrategy {
+    @Override
+    protected URI createLocationURI(String location) throws ProtocolException {
+        return super.createLocationURI(sanitizeUrl(location));
+    }
+
+    private String sanitizeUrl(String sanitizeURL) throws ProtocolException {
+        URI uri;
+        try {
+            URL url = new URL(URLDecoder.decode(sanitizeURL, "UTF-8"));
+            // https://stackoverflow.com/a/8962879/956415
+            uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
+        } catch (URISyntaxException | MalformedURLException | UnsupportedEncodingException e) {
+            throw new ProtocolException(e.getMessage(), e);
+        }
+
+        return uri.toString();
+    }
+}
+
+

--- a/src/test/java/de/undercouch/gradle/tasks/download/SanitizingLocationUriRedirectStrategyTest.java
+++ b/src/test/java/de/undercouch/gradle/tasks/download/SanitizingLocationUriRedirectStrategyTest.java
@@ -1,0 +1,57 @@
+package de.undercouch.gradle.tasks.download;
+
+import de.undercouch.gradle.tasks.download.internal.SanitizingLocationUriRedirectStrategy;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class SanitizingLocationUriRedirectStrategyTest {
+
+
+    SanitizingLocationUriRedirectStrategy underTest;
+
+    private final String basePath = "https://example.com";
+    private final String compliantLocation = "/somepath/some%20other%20path";
+
+    @BeforeEach
+    void setup() {
+        underTest = new SanitizingLocationUriRedirectStrategy();
+    }
+
+    @Test
+    void compliantLocationURI() throws URISyntaxException, HttpException {
+
+        HttpRequest request = Mockito.mock(HttpRequest.class);
+        when(request.getUri()).thenReturn(URI.create(basePath));
+        HttpResponse response = Mockito.mock(HttpResponse.class);
+        Header locationHeader = Mockito.mock(Header.class);
+        when(locationHeader.getValue()).thenReturn(basePath + compliantLocation);
+        when(response.getFirstHeader(any())).thenReturn(locationHeader);
+        assertEquals(URI.create(basePath + compliantLocation), underTest.getLocationURI(request, response, Mockito.mock(HttpContext.class)));
+    }
+
+    @Test
+    void nonCompliantLocationURI() throws URISyntaxException, HttpException {
+
+        HttpRequest request = Mockito.mock(HttpRequest.class);
+        when(request.getUri()).thenReturn(URI.create(basePath));
+        HttpResponse response = Mockito.mock(HttpResponse.class);
+        Header locationHeader = Mockito.mock(Header.class);
+        String nonCompliantLocation = "/somepath/some other path";
+        when(locationHeader.getValue()).thenReturn(basePath + nonCompliantLocation);
+        when(response.getFirstHeader(any())).thenReturn(locationHeader);
+        assertEquals(URI.create(basePath + compliantLocation), underTest.getLocationURI(request, response, Mockito.mock(HttpContext.class)));
+    }
+}


### PR DESCRIPTION
I've come across a site with wrong implementation of Location header. The URL contains spaces instead of %20. Modern browsers handle spaces by additional encoding to %20. This PR will allow gradle-download-task to do the same.

Current Location header in server response:
```
...
Location: https://crm.innovatrics.com/downloads/1739687026/30_Digital Onboarding Toolkit/DOT Digital Identity Service/dot-digital-identity-service-1.20.0.zip
```
Desired URL used for redirection:
```
https://crm.innovatrics.com/downloads/1739687026/30_Digital%20Onboarding%20Toolkit/DOT%20Digital%20Identity%20Service/dot-digital-identity-service-1.20.0.zip
```