### PR TITLE
Allow using http proxy for tunneling

### DIFF
--- a/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/DownloadAction.java
@@ -817,7 +817,7 @@ public class DownloadAction implements DownloadSpec, Serializable {
         req.setConfig(config);
 
         // add authentication information for proxy
-        String scheme = httpHost.getSchemeName();
+        String scheme = getProxyScheme();
         String proxyHost = System.getProperty(scheme + ".proxyHost");
         String proxyPort = System.getProperty(scheme + ".proxyPort");
         String proxyUser = System.getProperty(scheme + ".proxyUser");
@@ -884,6 +884,14 @@ public class DownloadAction implements DownloadSpec, Serializable {
 
             return responseHandler.handleResponse(response);
         });
+    }
+
+    private String getProxyScheme() {
+        Optional<String> scheme = Optional.ofNullable(System.getProperty("http.proxyHost"));
+        if(scheme.isPresent()) {
+            return "http";
+        }
+        return "https";
     }
 
     /**

--- a/src/main/java/de/undercouch/gradle/tasks/download/HttpTunnelProxySelector.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/HttpTunnelProxySelector.java
@@ -1,0 +1,33 @@
+package de.undercouch.gradle.tasks.download;
+
+import java.io.IOException;
+import java.net.*;
+import java.util.List;
+
+import static java.net.Proxy.NO_PROXY;
+
+public class HttpTunnelProxySelector extends ProxySelector {
+
+    private static final
+    ProxySelector defaultProxySelector = getDefault();
+
+    @Override
+    public List<Proxy> select(URI uri) {
+        try {
+            URI httpUri = new URI("http", uri.getAuthority(), uri.getPath(), uri.getQuery(), uri.getFragment());
+            List<Proxy> proxies = defaultProxySelector.select(httpUri);
+            if(proxies.get(0).equals(NO_PROXY)) {
+                return defaultProxySelector.select(uri);
+            }
+            return proxies;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+        defaultProxySelector.connectFailed(uri, sa, ioe);
+    }
+}
+

--- a/src/main/java/de/undercouch/gradle/tasks/download/internal/DefaultHttpClientFactory.java
+++ b/src/main/java/de/undercouch/gradle/tasks/download/internal/DefaultHttpClientFactory.java
@@ -14,6 +14,7 @@
 
 package de.undercouch.gradle.tasks.download.internal;
 
+import de.undercouch.gradle.tasks.download.HttpTunnelProxySelector;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
@@ -72,7 +73,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
         }
 
         // configure proxy from system environment
-        builder.setRoutePlanner(new SystemDefaultRoutePlanner(null));
+        builder.setRoutePlanner(new SystemDefaultRoutePlanner(new HttpTunnelProxySelector()));
         
         // use pooling connection manager to support multiple threads
         PoolingHttpClientConnectionManager cm;


### PR DESCRIPTION
Fixes #424

A 407 error occurs because you set the HttpHost with HTTPS, but the Apache CredentialsMatcher can't find any credentials. This happens since the proxy is always set as HTTP, and the default URI scheme for proxies is always set to HTTP.

The ProxySelector class is for setting up proxy with only http prefix. Without it, the proxy won't be used at all, as sun.net.spi.DefaultProxySelector searches for proxies by protocol and fails to match when url is set to HTTPS. 

Do you need me to rebase this on 5.6.0 version to release a hotfix too?